### PR TITLE
Build RISCV target in LLVM

### DIFF
--- a/config_toml.py
+++ b/config_toml.py
@@ -124,7 +124,7 @@ ar="{ar}"
         config_toml.write("""\
 [llvm]
 ninja = true
-targets = "AArch64;ARM;X86"
+targets = "AArch64;ARM;X86;RISCV"
 experimental-targets = ""
 use-libcxx = true
 [build]


### PR DESCRIPTION
This fix makes the build process step forward, but still failed.